### PR TITLE
Correct stamp field name. It failed on Dalvik (Android)

### DIFF
--- a/src/main/java/com/github/drochetti/javassist/maven/ClassTransformer.java
+++ b/src/main/java/com/github/drochetti/javassist/maven/ClassTransformer.java
@@ -230,7 +230,7 @@ public abstract class ClassTransformer {
     }
     
     private String createStampFieldName() {
-        return STAMP_FIELD_NAME+getClass().getName();
+        return STAMP_FIELD_NAME+getClass().getName().replaceAll(".", "_").replaceAll("$", "_");
     }
 
     private void initializeClass(final CtClass candidateClass) throws NotFoundException {


### PR DESCRIPTION
This patch prevents a really annoying issue on Android : 
https://code.google.com/p/android/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Type%20Status%20Owner%20Summary%20Stars&groupby=&sort=&id=64514

Please accept the PR, it should not impact other VMs. 
