### PR TITLE
Add javadocs and maven site. Issue #16

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -96,3 +96,8 @@ h2. How to contribute?
 
 p. If you think this project is useful for you, them there's a huge chance it's useful to others, so please feel free
 to fork, fix it, improve it and test it (the "Known limitations" above is a great way to start).
+
+h2. Documentation
+
+* <a href="https://travis-ci.org/icon-Systemhaus-GmbH/javassist-maven-plugin/site/latest">maven site</a>
+* <a href="https://travis-ci.org/icon-Systemhaus-GmbH/javassist-maven-plugin/wiki">wiki</a>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,14 @@
 		<url>https://github.com/icon-Systemhaus-GmbH/javassist-maven-plugin/issues</url>
 	</issueManagement>
 
+	<distributionManagement>
+		<site>
+			<id>github-pages-site</id>
+			<name>Deployment through GitHub's site deployment plugin</name>
+			<url>site/latest</url>
+		</site>
+	</distributionManagement>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.compiler.version>1.6</java.compiler.version>
@@ -66,8 +74,12 @@
 		<maven-plugin-api.version>3.2.1</maven-plugin-api.version>
 		<maven-plugin-annotations.version>3.3</maven-plugin-annotations.version>
 		<maven-core.version>3.2.1</maven-core.version>
+		<site-maven-plugin.version>0.9</site-maven-plugin.version>
+		<maven-site-plugin.version>3.3</maven-site-plugin.version>
+		<doxia-module-markdown.version>1.3</doxia-module-markdown.version>
 		<plexus-utils.version>3.0.17</plexus-utils.version>
 		<plexus-archiver.version>2.4.4</plexus-archiver.version>
+		<maven-javadoc-plugin.version>2.9</maven-javadoc-plugin.version>
 
 		<commons-io.version>2.4</commons-io.version>
 		<slf4j-api.version>1.7.7</slf4j-api.version>
@@ -84,6 +96,9 @@
 		<maven-artifact.version>3.2.1</maven-artifact.version>
 
 		<maven-plugin-plugin.version>3.2</maven-plugin-plugin.version>
+
+		<!-- https://github.com/github/maven-plugins -->
+		<github.global.server>github</github.global.server>
 	</properties>
 
 	<dependencyManagement>
@@ -270,6 +285,24 @@
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>${maven-plugin-plugin.version}</version>
 				</plugin>
+				<!-- deploy javadoc and maven site to github https://github.com/github/maven-plugins/issues/22 -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>${maven-site-plugin.version}</version>
+					<configuration>
+						<skipDeploy>true</skipDeploy>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<!-- | allows markdown syntax for site generation. To use it place 
+								files below | src/site/markdown/[filename].md -->
+							<groupId>org.apache.maven.doxia</groupId>
+							<artifactId>doxia-module-markdown</artifactId>
+							<version>${doxia-module-markdown.version}</version>
+						</dependency>
+					</dependencies>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -323,6 +356,69 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- http://blog.akquinet.de/2012/04/12/maven-sites-reloaded/ -->
+			<!-- http://minds.coremedia.com/2012/09/11/problem-solved-deploy-multi-module-maven-project-site-as-github-pages/ -->
+			<plugin>
+				<groupId>com.github.github</groupId>
+				<artifactId>site-maven-plugin</artifactId>
+				<version>${site-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>site-deploy-to-github</id>
+						<goals>
+							<goal>site</goal>
+						</goals>
+						<phase>site-deploy</phase>
+						<configuration>
+							<merge>true</merge>
+							<message>Creating site for ${project.version}</message>
+							<path>${project.distributionManagement.site.url}</path>
+							<excludes>
+								<exclude>dependencies/**</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>${maven-javadoc-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>attach-javadoc</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>aggregate</id>
+						<goals>
+							<goal>javadoc</goal>
+						</goals>
+						<phase>site</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>${maven-javadoc-plugin.version}</version>
+				<reportSets>
+					<reportSet>
+						<id>aggregate</id><!-- aggregate reportSet, for pom with modules -->
+						<inherited>false</inherited><!-- don't run aggregate in child modules -->
+						<reports>
+							<report>aggregate</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>


### PR DESCRIPTION
This PR solves most of issue #16. The site is generated by `mvn site`.

There is still some configuration needed in the contributor`s maven settings file to have it deployed on github pages : 
https://github.com/github/maven-plugins
