### PR TITLE
Rename filter to shouldTransform as per issue #29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.drochetti</groupId>
 	<artifactId>javassist-maven-plugin</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.0.3-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>Javassist Maven Plugin</name>

--- a/src/main/java/com/github/drochetti/javassist/maven/ClassTransformer.java
+++ b/src/main/java/com/github/drochetti/javassist/maven/ClassTransformer.java
@@ -64,12 +64,14 @@ public abstract class ClassTransformer {
      * CtClass myInterface = ClassPool.getDefault().get(MyInterface.class.getName());
      * return candidateClass.subtypeOf(myInterface);
      * </pre></code>
+     * Override this method to boost class transformations and discard classes you don't want
+     * to transform.
      *
      * @param candidateClass
      * @return {@code true} if the Class should be transformed; {@code false} otherwise.
      * @throws Exception
      */
-    protected boolean filter(final CtClass candidateClass) throws Exception {
+    protected boolean shouldTransform(final CtClass candidateClass) throws Exception {
         return true;
     }
 
@@ -163,7 +165,7 @@ public abstract class ClassTransformer {
                     classPool.importPackage(className);
                     final CtClass candidateClass = classPool.get(className);
                     initializeClass(candidateClass);
-                    if ( !hasStamp(candidateClass) && filter(candidateClass) ) {
+                    if ( !hasStamp(candidateClass) && shouldTransform(candidateClass) ) {
                         applyTransformations(candidateClass);
                         applyStamp(candidateClass);
                         candidateClass.writeFile(outputDir);

--- a/src/main/java/com/github/drochetti/javassist/maven/example/transformer/MethodCallClassTransformer.java
+++ b/src/main/java/com/github/drochetti/javassist/maven/example/transformer/MethodCallClassTransformer.java
@@ -70,9 +70,9 @@ public class MethodCallClassTransformer extends ClassTransformer {
 	}
 
 	@Override
-	protected boolean filter(final CtClass candidateClass) throws Exception {
+	protected boolean shouldTransform(final CtClass candidateClass) throws Exception {
 		return candidateClass != null && !isIntrospected(candidateClass)
-				&& super.filter(candidateClass);
+				&& super.shouldTransform(candidateClass);
 	}
 
 	@Override

--- a/src/test/java/com/github/drochetti/javassist/maven/JavassistTransformerExecutorTest.java
+++ b/src/test/java/com/github/drochetti/javassist/maven/JavassistTransformerExecutorTest.java
@@ -18,7 +18,6 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Test;
 
-@SuppressWarnings("restriction")
 public class JavassistTransformerExecutorTest {
     private final static File ROOT = new File("tmp");
     
@@ -83,14 +82,14 @@ public class JavassistTransformerExecutorTest {
 
         JavassistTransformerExecutor executor = new JavassistTransformerExecutor();
 
-        Method methodFilter = ClassTransformer.class.getDeclaredMethod("filter", CtClass.class); 
+        Method methodFilter = ClassTransformer.class.getDeclaredMethod("shouldTransform", CtClass.class); 
         Method methodApplyTransformation = ClassTransformer.class.getDeclaredMethod("applyTransformations", CtClass.class);
         
         Capture<CtClass> capturedClass1 = new Capture<CtClass>();
         Capture<CtClass> capturedClass2 = new Capture<CtClass>();
 
         ClassTransformer mockTransformer = EasyMock.createMock(ClassTransformer.class, methodFilter, methodApplyTransformation);
-        EasyMock.expect(mockTransformer.filter(EasyMock.capture(capturedClass1))).andReturn(true);
+        EasyMock.expect(mockTransformer.shouldTransform(EasyMock.capture(capturedClass1))).andReturn(true);
         EasyMock.expectLastCall();
         mockTransformer.applyTransformations(EasyMock.capture(capturedClass2));
         EasyMock.expectLastCall();
@@ -119,11 +118,11 @@ public class JavassistTransformerExecutorTest {
         
         JavassistTransformerExecutor executor = new JavassistTransformerExecutor();
         
-        Method methodFilter = ClassTransformer.class.getDeclaredMethod("filter", CtClass.class); 
+        Method methodFilter = ClassTransformer.class.getDeclaredMethod("shouldTransform", CtClass.class); 
         Method methodApplyTransformation = ClassTransformer.class.getDeclaredMethod("applyTransformations", CtClass.class);
         
         ClassTransformer mockTransformer = EasyMock.createMock(ClassTransformer.class, methodFilter, methodApplyTransformation);
-        EasyMock.expect(mockTransformer.filter((CtClass)EasyMock.anyObject())).andReturn(true);
+        EasyMock.expect(mockTransformer.shouldTransform((CtClass)EasyMock.anyObject())).andReturn(true);
         EasyMock.expectLastCall().times(2);
         mockTransformer.applyTransformations((CtClass)EasyMock.anyObject());
         EasyMock.expectLastCall().times(2);
@@ -150,11 +149,11 @@ public class JavassistTransformerExecutorTest {
         
         JavassistTransformerExecutor executor = new JavassistTransformerExecutor();
         
-        Method methodFilter = ClassTransformer.class.getDeclaredMethod("filter", CtClass.class); 
+        Method methodFilter = ClassTransformer.class.getDeclaredMethod("shouldTransform", CtClass.class); 
         Method methodApplyTransformation = ClassTransformer.class.getDeclaredMethod("applyTransformations", CtClass.class);
         
         ClassTransformer mockTransformer = EasyMock.createMock(ClassTransformer.class, methodFilter, methodApplyTransformation);
-        EasyMock.expect(mockTransformer.filter((CtClass)EasyMock.anyObject())).andReturn(true);
+        EasyMock.expect(mockTransformer.shouldTransform((CtClass)EasyMock.anyObject())).andReturn(true);
         EasyMock.expectLastCall().times(1);
         mockTransformer.applyTransformations((CtClass)EasyMock.anyObject());
         EasyMock.expectLastCall().times(1);
@@ -167,7 +166,7 @@ public class JavassistTransformerExecutorTest {
         executor.setOutputDirectory(root.getAbsolutePath());
         
         //when
-        //execute twice should not applyTransformations twice, nor should it filter it twice
+        //execute twice should not applyTransformations twice, nor should it shouldTransform it twice
         executor.execute();
         executor.execute();
         
@@ -183,17 +182,17 @@ public class JavassistTransformerExecutorTest {
         
         JavassistTransformerExecutor executor = new JavassistTransformerExecutor();
         
-        Method methodFilter = ClassTransformer.class.getDeclaredMethod("filter", CtClass.class); 
+        Method methodFilter = ClassTransformer.class.getDeclaredMethod("shouldTransform", CtClass.class); 
         Method methodApplyTransformation = ClassTransformer.class.getDeclaredMethod("applyTransformations", CtClass.class);
         
         ClassTransformer mockTransformer = EasyMock.createMock(ClassTransformer.class, methodFilter, methodApplyTransformation);
-        EasyMock.expect(mockTransformer.filter((CtClass)EasyMock.anyObject())).andReturn(true);
+        EasyMock.expect(mockTransformer.shouldTransform((CtClass)EasyMock.anyObject())).andReturn(true);
         EasyMock.expectLastCall().times(1);
         mockTransformer.applyTransformations((CtClass)EasyMock.anyObject());
         EasyMock.expectLastCall().times(1);
         
         ClassTransformer mockTransformer2 = EasyMock.createMock(ClassTransformer.class, methodFilter, methodApplyTransformation);
-        EasyMock.expect(mockTransformer2.filter((CtClass)EasyMock.anyObject())).andReturn(true);
+        EasyMock.expect(mockTransformer2.shouldTransform((CtClass)EasyMock.anyObject())).andReturn(true);
         EasyMock.expectLastCall().times(1);
         mockTransformer2.applyTransformations((CtClass)EasyMock.anyObject());
         EasyMock.expectLastCall().times(1);


### PR DESCRIPTION
Simply renamed the method.

As this version is not backward compatible, I increased version number to `1.0.3-SNAPSHOT`
