### PR TITLE
Implements the part of publishing procedure related to pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+
 	<groupId>com.github.drochetti</groupId>
 	<artifactId>javassist-maven-plugin</artifactId>
 	<version>1.0.2-SNAPSHOT</version>


### PR DESCRIPTION
This just add a parent from sonatype to javassist.

You will still have to follow the procedure of sonatype for the rest. Including addiding these lines to your settings file : 

``` xml

<servers>
    <server>
      <id>sonatype-nexus-snapshots</id>
      <username>your-jira-id</username>
      <password>your-jira-pwd</password>
    </server>
    <server>
      <id>sonatype-nexus-staging</id>
      <username>your-jira-id</username>
      <password>your-jira-pwd</password>
    </server>
  </servers>
```

Issue https://github.com/icon-Systemhaus-GmbH/javassist-maven-plugin/issues/2
